### PR TITLE
trivial: predicted timestamp fix

### DIFF
--- a/hawkular-datamining-forecast/src/main/java/org/hawkular/datamining/forecast/models/AbstractExponentialSmoothing.java
+++ b/hawkular-datamining-forecast/src/main/java/org/hawkular/datamining/forecast/models/AbstractExponentialSmoothing.java
@@ -114,7 +114,7 @@ public abstract class AbstractExponentialSmoothing implements TimeSeriesModel {
         for (long i = 1; i <= nAhead; i++) {
 
             DataPoint predictedPoint = new DataPoint(calculatePrediction(i, null),
-                    lastTimestamp + i*metricContext.getCollectionInterval());
+                    lastTimestamp + i*metricContext.getCollectionInterval()*1000);
 
             result.add(predictedPoint);
         }


### PR DESCRIPTION
When calculating timestamps of predicted points collection interval is set to ms.

@Jiri-Kremser could you please review? 