### PR TITLE
Static factory method for creating exp. smoothing models

### DIFF
--- a/hawkular-datamining-forecast/src/main/java/org/hawkular/datamining/forecast/models/DoubleExponentialSmoothing.java
+++ b/hawkular-datamining-forecast/src/main/java/org/hawkular/datamining/forecast/models/DoubleExponentialSmoothing.java
@@ -67,19 +67,8 @@ public class DoubleExponentialSmoothing extends AbstractExponentialSmoothing {
         }
     }
 
-    public DoubleExponentialSmoothing() {
-        this(DEFAULT_LEVEL_SMOOTHING, DEFAULT_TREND_SMOOTHING, ImmutableMetricContext.getDefault());
-    }
 
-    public DoubleExponentialSmoothing(MetricContext metricContext) {
-        this(DEFAULT_LEVEL_SMOOTHING, DEFAULT_TREND_SMOOTHING, metricContext);
-    }
-
-    public DoubleExponentialSmoothing(double levelSmoothing, double trendSmoothing) {
-        this(levelSmoothing, trendSmoothing, ImmutableMetricContext.getDefault());
-    }
-
-    public DoubleExponentialSmoothing(double levelSmoothing, double trendSmoothing, MetricContext metricContext) {
+    private DoubleExponentialSmoothing(double levelSmoothing, double trendSmoothing, MetricContext metricContext) {
         super(metricContext);
 
         if (levelSmoothing < MIN_LEVEL_TREND_SMOOTHING || levelSmoothing > MAX_LEVEL_TREND_SMOOTHING) {
@@ -91,6 +80,24 @@ public class DoubleExponentialSmoothing extends AbstractExponentialSmoothing {
 
         this.levelSmoothing = levelSmoothing;
         this.trendSmoothing = trendSmoothing;
+    }
+
+    public static DoubleExponentialSmoothing createDefault() {
+        return new DoubleExponentialSmoothing(DEFAULT_LEVEL_SMOOTHING, DEFAULT_TREND_SMOOTHING,
+                ImmutableMetricContext.getDefault());
+    }
+
+    public static DoubleExponentialSmoothing createWithMetric(MetricContext metricContext) {
+        return new DoubleExponentialSmoothing(DEFAULT_LEVEL_SMOOTHING, DEFAULT_TREND_SMOOTHING, metricContext);
+    }
+
+    public static DoubleExponentialSmoothing createWithSmoothingParams(double levelSmoothing, double trendSmoothing) {
+        return new DoubleExponentialSmoothing(levelSmoothing, trendSmoothing, ImmutableMetricContext.getDefault());
+    }
+
+    public static DoubleExponentialSmoothing createCustom(double levelSmoothing, double trendSmoothing,
+                                                          MetricContext metricContext) {
+        return new DoubleExponentialSmoothing(levelSmoothing, trendSmoothing, metricContext);
     }
 
     @Override
@@ -179,7 +186,7 @@ public class DoubleExponentialSmoothing extends AbstractExponentialSmoothing {
         public TimeSeriesModel minimizedMSE(List<DataPoint> dataPoints) {
 
             if (dataPoints.isEmpty()) {
-                return new DoubleExponentialSmoothing();
+                return DoubleExponentialSmoothing.createDefault();
             }
 
             optimize(new double[]{DEFAULT_LEVEL_SMOOTHING, DEFAULT_TREND_SMOOTHING}, costFunction(dataPoints));

--- a/hawkular-datamining-forecast/src/main/java/org/hawkular/datamining/forecast/models/SimpleExponentialSmoothing.java
+++ b/hawkular-datamining-forecast/src/main/java/org/hawkular/datamining/forecast/models/SimpleExponentialSmoothing.java
@@ -65,21 +65,25 @@ public class SimpleExponentialSmoothing extends AbstractExponentialSmoothing {
     }
 
 
-    public SimpleExponentialSmoothing() {
-        this(DEFAULT_LEVEL_SMOOTHING, ImmutableMetricContext.getDefault());
-    }
-
-    public SimpleExponentialSmoothing(double levelSmoothing) {
-        this(DEFAULT_LEVEL_SMOOTHING, ImmutableMetricContext.getDefault());
-    }
-
-    public SimpleExponentialSmoothing(double levelSmoothing, MetricContext metricContext) {
+    private SimpleExponentialSmoothing(double levelSmoothing, MetricContext metricContext) {
         super(metricContext);
 
         if (levelSmoothing < MIN_LEVEL_SMOOTHING || levelSmoothing > MAX_LEVEL_SMOOTHING) {
             throw new IllegalArgumentException("Level parameter should be in interval 0-1");
         }
         this.levelSmoothing = levelSmoothing;
+    }
+
+    public static SimpleExponentialSmoothing createDefault() {
+        return new SimpleExponentialSmoothing(DEFAULT_LEVEL_SMOOTHING, ImmutableMetricContext.getDefault());
+    }
+
+    public static SimpleExponentialSmoothing createWithSmoothingParam(double levelSmoothing) {
+        return new SimpleExponentialSmoothing(levelSmoothing, ImmutableMetricContext.getDefault());
+    }
+
+    public static SimpleExponentialSmoothing createCustom(double levelSmoothing, MetricContext metricContext) {
+        return new SimpleExponentialSmoothing(levelSmoothing, metricContext);
     }
 
     @Override
@@ -160,7 +164,7 @@ public class SimpleExponentialSmoothing extends AbstractExponentialSmoothing {
         @Override
         public TimeSeriesModel minimizedMSE(List<DataPoint> dataPoints) {
             if (dataPoints.isEmpty()) {
-                return new SimpleExponentialSmoothing();
+                return SimpleExponentialSmoothing.createDefault();
             }
 
             optimize(new double[]{DEFAULT_LEVEL_SMOOTHING}, costFunction(dataPoints));

--- a/hawkular-datamining-forecast/src/main/java/org/hawkular/datamining/forecast/models/TripleExponentialSmoothing.java
+++ b/hawkular-datamining-forecast/src/main/java/org/hawkular/datamining/forecast/models/TripleExponentialSmoothing.java
@@ -69,24 +69,8 @@ public class TripleExponentialSmoothing extends AbstractExponentialSmoothing {
         }
     }
 
-    public TripleExponentialSmoothing(int periods) {
-        this(periods, DEFAULT_LEVEL_SMOOTHING, DEFAULT_TREND_SMOOTHING, DEFAULT_SEASONAL_SMOOTHING,
-                ImmutableMetricContext.getDefault());
-    }
 
-    public TripleExponentialSmoothing(int periods, MetricContext metricContext) {
-        this(periods, DEFAULT_LEVEL_SMOOTHING, DEFAULT_TREND_SMOOTHING, DEFAULT_SEASONAL_SMOOTHING,
-                metricContext);
-    }
-
-    public TripleExponentialSmoothing(double levelSmoothing, double trendSmoothing, double seasonalSmoothing,
-                                      State state, MetricContext metricContext) {
-
-        this(state.periods.length, levelSmoothing, trendSmoothing, seasonalSmoothing, metricContext);
-        this.state = state;
-    }
-
-    public TripleExponentialSmoothing(int periods, double levelSmoothing, double trendSmoothing,
+    private TripleExponentialSmoothing(int periods, double levelSmoothing, double trendSmoothing,
                                       double seasonalSmoothing, MetricContext metricContext) {
         super(metricContext);
 
@@ -110,6 +94,41 @@ public class TripleExponentialSmoothing extends AbstractExponentialSmoothing {
         this.seasonalSmoothing = seasonalSmoothing;
     }
 
+    public static TripleExponentialSmoothing createDefault(int periods) {
+        return new TripleExponentialSmoothing(periods, DEFAULT_LEVEL_SMOOTHING, DEFAULT_TREND_SMOOTHING,
+                DEFAULT_SEASONAL_SMOOTHING, ImmutableMetricContext.getDefault());
+    }
+
+    public static TripleExponentialSmoothing createWithMetric(int periods, MetricContext metricContext) {
+        return new TripleExponentialSmoothing(periods, DEFAULT_LEVEL_SMOOTHING, DEFAULT_TREND_SMOOTHING,
+                DEFAULT_SEASONAL_SMOOTHING, metricContext);
+    }
+
+    public static TripleExponentialSmoothing createWithSmoothingParams(int periods, double levelSmoothing,
+                                                                       double trendSmoothing,
+                                                                       double seasonalSmoothing) {
+        return new TripleExponentialSmoothing(periods, levelSmoothing, trendSmoothing, seasonalSmoothing,
+                ImmutableMetricContext.getDefault());
+    }
+
+    public static TripleExponentialSmoothing createCustom(int periods, double levelSmoothing,
+                                                          double trendSmoothing,
+                                                          double seasonalSmoothing,
+                                                          MetricContext metricContext) {
+        return new TripleExponentialSmoothing(periods, levelSmoothing, trendSmoothing, seasonalSmoothing,
+                metricContext);
+    }
+
+    public static TripleExponentialSmoothing createWithState(State state, double levelSmoothing, double trendSmoothing,
+                                                             double seasonalSmoothing, MetricContext metricContext) {
+        TripleExponentialSmoothing tripleExponentialSmoothing =
+                new TripleExponentialSmoothing(state.periods.length, levelSmoothing, trendSmoothing,
+                        seasonalSmoothing, metricContext);
+        tripleExponentialSmoothing.state = state;
+
+        return tripleExponentialSmoothing;
+    }
+
     @Override
     public String name() {
         return "Triple exponential smoothing";
@@ -126,7 +145,7 @@ public class TripleExponentialSmoothing extends AbstractExponentialSmoothing {
     }
 
     public static State initState(List<DataPoint> dataPoints, int periods, MetricContext metricContext) {
-        return new TripleExponentialSmoothing(periods, metricContext).initState(dataPoints);
+        return TripleExponentialSmoothing.createWithMetric(periods, metricContext).initState(dataPoints);
     }
 
     @Override
@@ -363,7 +382,7 @@ public class TripleExponentialSmoothing extends AbstractExponentialSmoothing {
 
             State state = new State(level, slope, periods, firstTimestamp);
 
-            TripleExponentialSmoothing model = new TripleExponentialSmoothing(alpha, beta, gamma, state,
+            TripleExponentialSmoothing model = TripleExponentialSmoothing.createWithState(state, alpha, beta, gamma,
                     getMetricContext());
             return model;
         }

--- a/hawkular-datamining-forecast/src/test/java/org/hawkular/datamining/forecast/models/DoubleExponentialSmoothingTest.java
+++ b/hawkular-datamining-forecast/src/test/java/org/hawkular/datamining/forecast/models/DoubleExponentialSmoothingTest.java
@@ -57,7 +57,7 @@ public class DoubleExponentialSmoothingTest extends AbstractTest {
         DoubleExponentialSmoothing.Optimizer optimizer = DoubleExponentialSmoothing.optimizer();
         TimeSeriesModel modelInit = optimizer.minimizedMSE(rModel.getData());
 
-        TimeSeriesModel modelLearn = new DoubleExponentialSmoothing(optimizer.result()[0], optimizer.result()[1]);
+        TimeSeriesModel modelLearn = DoubleExponentialSmoothing.createWithSmoothingParams(optimizer.result()[0], optimizer.result()[1]);
         modelLearn.learn(rModel.getData());
 
         AccuracyStatistics batchInitStatistics = modelInit.initStatistics();
@@ -74,7 +74,7 @@ public class DoubleExponentialSmoothingTest extends AbstractTest {
         TimeSeriesModel modelInit = optimizer.minimizedMSE(rModel.getData());
 
         TimeSeriesModel continuousModel = new ContinuousModel(
-                new DoubleExponentialSmoothing(optimizer.result()[0], optimizer.result()[1]));
+                DoubleExponentialSmoothing.createWithSmoothingParams(optimizer.result()[0], optimizer.result()[1]));
 
         rModel.getData().forEach(dataPoint -> continuousModel.learn(dataPoint));
 

--- a/hawkular-datamining-forecast/src/test/java/org/hawkular/datamining/forecast/models/SimpleExponentialSmoothingTest.java
+++ b/hawkular-datamining-forecast/src/test/java/org/hawkular/datamining/forecast/models/SimpleExponentialSmoothingTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.Collections;
 
 import org.hawkular.datamining.forecast.AbstractTest;
-import org.hawkular.datamining.forecast.ImmutableMetricContext;
 import org.hawkular.datamining.forecast.ModelData;
 import org.hawkular.datamining.forecast.ModelReader;
 import org.hawkular.datamining.forecast.stats.AccuracyStatistics;
@@ -56,8 +55,7 @@ public class SimpleExponentialSmoothingTest extends AbstractTest {
         SimpleExponentialSmoothing.Optimizer optimizer = SimpleExponentialSmoothing.optimizer();
         TimeSeriesModel modelInit = optimizer.minimizedMSE(rModel.getData());
 
-        TimeSeriesModel modelLearn = new SimpleExponentialSmoothing(optimizer.result()[0],
-                ImmutableMetricContext.getDefault());
+        TimeSeriesModel modelLearn = SimpleExponentialSmoothing.createWithSmoothingParam(optimizer.result()[0]);
         modelLearn.learn(rModel.getData());
 
         AccuracyStatistics batchInitStatistics = modelInit.initStatistics();
@@ -73,7 +71,8 @@ public class SimpleExponentialSmoothingTest extends AbstractTest {
         SimpleExponentialSmoothing.Optimizer optimizer = SimpleExponentialSmoothing.optimizer();
         TimeSeriesModel modelInit = optimizer.minimizedMSE(rModel.getData());
 
-        TimeSeriesModel continuousModel = new ContinuousModel(new SimpleExponentialSmoothing(optimizer.result()[0]));
+        TimeSeriesModel continuousModel = new ContinuousModel(
+                SimpleExponentialSmoothing.createWithSmoothingParam(optimizer.result()[0]));
 
         rModel.getData().forEach(dataPoint -> {
 

--- a/hawkular-datamining-forecast/src/test/java/org/hawkular/datamining/forecast/models/TripleExponentialSmoothingTest.java
+++ b/hawkular-datamining-forecast/src/test/java/org/hawkular/datamining/forecast/models/TripleExponentialSmoothingTest.java
@@ -88,8 +88,9 @@ public class TripleExponentialSmoothingTest extends AbstractTest {
                         Arrays.copyOfRange(optimizer.result(), 5, optimizer.result().length),
                         rModel.getData().get(0).getTimestamp());
 
-        TimeSeriesModel modelLearn = new TripleExponentialSmoothing(optimizer.result()[0], optimizer.result()[1],
-                optimizer.result()[2], state, ImmutableMetricContext.getDefault());
+        TimeSeriesModel modelLearn = TripleExponentialSmoothing.createWithState(state, optimizer.result()[0],
+                optimizer.result()[1],
+                optimizer.result()[2],  ImmutableMetricContext.getDefault());
         modelLearn.learn(rModel.getData());
 
         AccuracyStatistics batchInitStatistics = modelInit.initStatistics();
@@ -102,7 +103,7 @@ public class TripleExponentialSmoothingTest extends AbstractTest {
     public void testInit() throws IOException {
        ModelData rModel = ModelReader.read("sineLowVarMedium");
 
-        TripleExponentialSmoothing tripleExponentialSmoothing = new TripleExponentialSmoothing(rModel.getPeriods());
+        TripleExponentialSmoothing tripleExponentialSmoothing = TripleExponentialSmoothing.createDefault(rModel.getPeriods());
 
         AccuracyStatistics initStat = tripleExponentialSmoothing.init(rModel.getData());
         Assert.assertNotNull(initStat);


### PR DESCRIPTION
Constructors for exp. smoothing contains lot of parameter therefore named static factory methods are better than constructors.


@Jiri-Kremser could you please review? 